### PR TITLE
Add support for MBN header v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ The `-v`/`--version` option must be set correctly depending on the chipset:
 - **`-v3` (default):** MSM8916, MSM8939, MSM8953
   - MSM8909, MDM9607 (they usually accept unsigned ELF images as well)
 - **`-v5`:** MSM8998, SDM845
-- **`-v6`:** SM8150
+- **`-v6`:** SM8150, IPQ9574, IPQ5332
   - In case of problems, try using `-v5` instead. Sometimes both seem to be supported.
+- **`-v7`:** IPQ5424
 
 The list of chipsets is not complete, most other Qualcomm chipsets likely use one of the already supported
 versions above or an older/newer version that is not supported yet by [qtestsign].
@@ -56,7 +57,7 @@ versions above or an older/newer version that is not supported yet by [qtestsign
 ## Supported firmware
 Qualcomm's own signing tool is proprietary and not publicly available. [qtestsign] was created to allow
 building open-source firmware projects without access to Qualcomm's tool, e.g.:
-- `aboot`: [U-Boot] bootloader (for DragonBoard 410c)
+- `aboot`: [U-Boot] bootloader (for DragonBoard 410c, QCA SoCs etc..)
 - `aboot`: [Qualcomm's fork of LK (Little Kernel)], used as bootloader on older platforms
 - `abl`: [Qualcomm's Android Bootloader for UEFI], used on newer platforms
 - `hyp`: [qhypstub], [tfalkstub]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,10 @@ from Qualcomm's whitepaper _"Secure Boot and Image Authentication"_ (both
 [v1.0](https://www.qualcomm.com/media/documents/files/secure-boot-and-image-authentication-technical-overview-v1-0.pdf) and
 [v2.0](https://www.qualcomm.com/media/documents/files/secure-boot-and-image-authentication-technical-overview-v2-0.pdf)).
 Some implementation details (e.g. the exact MBN header format) are adapted from [signlk] and [coreboot]
-(`util/qualcomm/mbn_tools.py`) available under a `BSD-3-Clause` license.
+(`util/qualcomm/mbn_tools.py`, `util/cbfstool/platform_fixups.c`) available under a `BSD-3-Clause` license.
+
+For QCA chipsets, Qualcomm maintains a similar set of tools at https://git.codelinaro.org/clo/qsdk/oss/system/tools/meta
+available under a `ISC` license.
 
 [qtestsign]: https://github.com/msm8916-mainline/qtestsign
 [cryptography]: https://cryptography.io

--- a/fw/hashseg.py
+++ b/fw/hashseg.py
@@ -199,7 +199,7 @@ class HashSegmentV7(_HashSegment):
 	common_metadata_size: int = 24  # Size of "common metadata" below
 	metadata_size_qcom: int = 0  # Size of metadata from Qualcomm
 	metadata_size: int = 0  # Size of metadata from OEM
-	hash_table_size: int = 0
+	hash_size: int = 0  # Size of hashes for all program segments
 	signature_size_qcom: int = 0  # Size of signature from Qualcomm
 	cert_chain_size_qcom: int = 0  # Size of certificate chain from Qualcomm
 	signature_size: int = 0  # Size of attestation signature

--- a/fw/hashseg.py
+++ b/fw/hashseg.py
@@ -241,7 +241,7 @@ class HashSegmentV7(_HashSegment):
 
 	def pack(self):
 		return self.pack_header() \
-			+ self.metadata + self.metadata_qcom \
+			+ self.metadata_qcom + self.metadata \
 			+ b''.join(self.hashes) \
 			+ self.signature_qcom + self.cert_chain_qcom \
 			+ self.signature + self.cert_chain

--- a/fw/hashseg.py
+++ b/fw/hashseg.py
@@ -55,7 +55,7 @@ CERT_CHAIN_ALIGN = 16
 
 # According to the v2.0 PDF the metadata is 128 bytes long, but this does not
 # seem to work. All official firmware seems to use 120 bytes instead.
-METADATA_SIZE = 120
+MBN_V6_METADATA_SIZE = 120
 
 
 def _align(i: int, alignment: int) -> int:
@@ -258,9 +258,9 @@ def generate(elff: elf.Elf, version: int, sw_id: int):
 
 	hash_seg = HashSegment[version]()
 
-	if version >= 6:
+	if version == 6:
 		# TODO: Figure out metadata format and fill this with useful data
-		hash_seg.metadata = b'\0' * METADATA_SIZE
+		hash_seg.metadata = b'\0' * MBN_V6_METADATA_SIZE
 
 	# Software ID is mandatory for MBN v7
 	if version == 7:

--- a/fw/hashseg.py
+++ b/fw/hashseg.py
@@ -196,19 +196,21 @@ class HashSegmentV6(HashSegmentV5):
 class HashSegmentV7(_HashSegment):
 	version: int = 7  # Header version number
 
-	common_metadata_size: int = 24 # This defaults to 24 (seems like the total size of the last 6 fields)
+	common_metadata_size: int = 24  # Size of "common metadata" below
 	metadata_size_qcom: int = 0  # Size of metadata from Qualcomm
-	metadata_size: int = 0	# Size of metadata from OEM
+	metadata_size: int = 0  # Size of metadata from OEM
 	hash_table_size: int = 0
 	signature_size_qcom: int = 0  # Size of signature from Qualcomm
 	cert_chain_size_qcom: int = 0  # Size of certificate chain from Qualcomm
 	signature_size: int = 0  # Size of attestation signature
 	cert_chain_size: int = 0  # Size of certificate chain
+
+	# Common metadata, placed directly after MBNv7 header
 	common_metadata_major_version: int = 0
 	common_metadata_minor_version: int = 0
-	software_id: int = 0 # mandatory
+	software_id: int = 0  # Type of software image, mandatory
 	secondary_software_id: int = 0
-	hash_table_algorithm: int = 3 # SHA384
+	hash_table_algorithm: int = 3  # SHA384
 	measurement_register_target: int = 0
 
 	metadata_qcom = b''
@@ -224,7 +226,8 @@ class HashSegmentV7(_HashSegment):
 		super().update(dest_addr)
 		self.metadata_size_qcom = len(self.metadata_qcom)
 		self.metadata_size = len(self.metadata)
-		self.total_size += self.common_metadata_size + self.metadata_size_qcom + self.metadata_size
+		# self.common_metadata_size is already included as part of the header
+		self.total_size += self.metadata_size_qcom + self.metadata_size
 
 	def check(self):
 		super().check()
@@ -331,3 +334,4 @@ def generate(elff: elf.Elf, version: int, sw_id: int):
 
 	# And finally, assemble the hash segment
 	hash_phdr.data = hash_seg.pack()
+	assert len(hash_phdr.data) == hash_phdr.p_filesz

--- a/fw/hashseg.py
+++ b/fw/hashseg.py
@@ -226,13 +226,18 @@ class HashSegmentV7(_HashSegment):
 		super().update(dest_addr)
 		self.metadata_size_qcom = len(self.metadata_qcom)
 		self.metadata_size = len(self.metadata)
+		self.signature_size_qcom = len(self.signature_qcom)
+		self.cert_chain_size_qcom = len(self.cert_chain_qcom)
 		# self.common_metadata_size is already included as part of the header
 		self.total_size += self.metadata_size_qcom + self.metadata_size
+		self.total_size += self.signature_size_qcom + self.cert_chain_size_qcom
 
 	def check(self):
 		super().check()
 		assert len(self.metadata_qcom) == self.metadata_size_qcom
 		assert len(self.metadata) == self.metadata_size
+		assert len(self.signature_qcom) == self.signature_size_qcom
+		assert len(self.cert_chain_qcom) == self.cert_chain_size_qcom
 
 	def pack(self):
 		return self.pack_header() \

--- a/qtestsign.py
+++ b/qtestsign.py
@@ -33,6 +33,9 @@ FW_SW_ID = {
 	"aop": 0x21,
 	"qup": 0x24,
 	"xbl-config": 0x25,
+	"cdsp-dtb": 0x52,
+	"adsp-dtb": 0x53,
+	"av1": 0x69,
 }
 
 

--- a/qtestsign.py
+++ b/qtestsign.py
@@ -58,7 +58,7 @@ parser = argparse.ArgumentParser(description="""
 """)
 parser.add_argument('type', choices=FW_SW_ID.keys(), help="Firmware type (for SW_ID)")
 parser.add_argument('elf', type=argparse.FileType('rb'), help="ELF image to sign")
-parser.add_argument('-v', '--version', type=int, choices=[3, 5, 6], default=3,
+parser.add_argument('-v', '--version', type=int, choices=[3, 5, 6, 7], default=3,
 					help="MBN header version. Must be set correctly depending on the target chipset. "
 						 "See README for details.")
 parser.add_argument('-o', '--output', type=Path, help="Output file")


### PR DESCRIPTION
It's tested on a IPQ5424 based board without secure boot enabled. Not sure if it's compatible with snapdragon SoCs.