### PR TITLE
Add pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ On many distributions this will likely be already installed by default (but perh
 Alternatively you can install it with pip:
 
 ```
-$ pip install -r requirements.txt
+$ pip install .
 ```
+
+If you are developing or modifying the tool, use `pip install -e .` instead so your code changes take effect immediately.
 
 Then, just use `./qtestsign.py --help` to figure out how the tool works. You need to specify the firmware type
 and the ELF image to sign, e.g. for [U-Boot]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "qtestsign"
+version = "0.0"
+requires-python = ">=3.7"
+dependencies = [
+  "cryptography>=3.1",
+]
+
+[tool.setuptools.packages.find]
+namespaces = true
+include = ["mbn"]
+
+[tool.setuptools]
+script-files = ["qtestsign.py", "merge.py", "patchxbl.py", "strip.py", "region.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-cryptography>=3.1


### PR DESCRIPTION
pybuild defaults to the distutils plugin which requires setup.py. Add a minimal pyproject.toml using the setuptools backend. The mbn package is discovered via namespace package find and the top-level scripts are installed as script-files.